### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
   Non-official AMap <a href="https://github.com/modelcontextprotocol">Model Context Protocol (MCP)</a> server that enables interaction with AMap powerful location related service. You can use in the following MCP clients like <a href="https://www.cursor.so">Cursor</a>, <a href="https://www.anthropic.com/claude">Claude Desktop</a>, <a href="https://cline.bot/">Cline</a> </a>, <a href="https://windsurf.com/editor">Windsurf</a> and other Client.
 </p>
 
+<a href="https://glama.ai/mcp/servers/@Francis235/amap-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Francis235/amap-mcp/badge" alt="AMap Server MCP server" />
+</a>
+
 ## Prerequisite
 
 1. python 3.10+;
@@ -28,4 +32,3 @@ Go to Cursor -> Cursor Settings -> MCP, click `Add new global MCP server`, and m
 
 A demonstration video:
 ![Demo](https://raw.githubusercontent.com/Francis235/amap-mcp/master/.assets/amap-demo.gif)
-


### PR DESCRIPTION
This PR adds a badge for the [AMap MCP Server](https://glama.ai/mcp/servers/@Francis235/amap-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Francis235/amap-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Francis235/amap-mcp/badge" alt="AMap Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.